### PR TITLE
Changes to sync

### DIFF
--- a/src/draw.h
+++ b/src/draw.h
@@ -1,4 +1,5 @@
-
+#ifndef __view_draw_h
+#define __view_draw_h
 #include <complex.h>
 
 
@@ -15,3 +16,4 @@ extern void draw(int X, int Y, int rgbstr, unsigned char* rgbbuf,
 	long str, const complex float* buf);
 
 
+#endif //__view_draw_h

--- a/src/main.c
+++ b/src/main.c
@@ -19,7 +19,8 @@
 
 #include "view.h"
 
-
+extern gboolean window_clone(GtkWidget *widget, gpointer data);
+extern gboolean window_callback(GtkWidget *widget, gpointer data);
 
 static const char usage_str[] = "<image> ...";
 static const char help_str[] = "View images.";
@@ -35,13 +36,26 @@ int main(int argc, char* argv[])
 
 	cmdline(&argc, argv, 1, 100, usage_str, help_str, ARRAY_SIZE(opts), opts);
 
+	struct view_s* v = NULL;
 	for (int i = 1; i < argc; i++) {
 
 		long dims[DIMS];
 		complex float* x = load_cfl(argv[i], DIMS, dims);
-	
+
 		// FIXME: we never delete them
-		window_new(argv[i], NULL, dims, x);
+		struct view_s* v2 = window_new(argv[i], NULL, dims, x);
+		// If multiple files are passed on the commandline, add them to window
+		// list. This code is copied from window_clone(). This enables sync of
+		// windowing and so on...
+		if ( NULL != v) {
+			v2->next = v->next;
+			v->next->prev = v2;
+			v2->prev = v;
+			v->next = v2;
+			window_callback(NULL, v);
+		} else {
+			v = v2;
+		}
 	}
 
 	gtk_main();

--- a/src/main.c
+++ b/src/main.c
@@ -20,8 +20,8 @@
 
 #include "view.h"
 
-extern gboolean window_clone(GtkWidget *widget, gpointer data);
-extern gboolean window_callback(GtkWidget *widget, gpointer data);
+
+void window_connect_sync(struct view_s* , struct view_s* );
 
 static const char usage_str[] = "<image> ...";
 static const char help_str[] = "View images.";
@@ -52,14 +52,9 @@ int main(int argc, char* argv[])
 		// FIXME: we never delete them
 		struct view_s* v2 = window_new(argv[i], NULL, dims, x);
 		// If multiple files are passed on the commandline, add them to window
-		// list. This code is copied from window_clone(). This enables sync of
-		// windowing and so on...
+		// list. This enables sync of windowing and so on...
 		if ( NULL != v) {
-			v2->next = v->next;
-			v->next->prev = v2;
-			v2->prev = v;
-			v->next = v2;
-			window_callback(NULL, v);
+			window_connect_sync(v, v2);
 		} else {
 			v = v2;
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
  */
 
 #include <complex.h>
+#include <string.h>
 
 #include <gtk/gtk.h>
 
@@ -38,8 +39,14 @@ int main(int argc, char* argv[])
 
 	struct view_s* v = NULL;
 	for (int i = 1; i < argc; i++) {
-
 		long dims[DIMS];
+
+		// if the filename ends in ".hdr", ".cfl" or just "." (from
+		// tab-completion), just replace the "." with a \0-character.
+		char* dot = strrchr(argv[i], '.');
+		if ( NULL != dot && ( !strcmp(dot, ".cfl") || !strcmp(dot, ".hdr") || !strcmp(dot, ".") ) ) {
+			*dot = '\0';
+		}
 		complex float* x = load_cfl(argv[i], DIMS, dims);
 
 		// FIXME: we never delete them

--- a/src/view.c
+++ b/src/view.c
@@ -401,6 +401,29 @@ extern gboolean toggle_sync(GtkWidget *widget, GtkToggleButton* button, gpointer
 }
 
 
+extern gboolean update_status_bar( struct view_s* v, int x2, int y2)
+{
+	float pos[DIMS];
+
+	for (int i = 0; i < DIMS; i++) {
+		pos[i] = v->pos[i];
+	}
+
+	pos[v->xdim] = x2;
+	pos[v->ydim] = y2;
+
+	complex float val = sample(DIMS, pos, v->dims, v->strs, v->data);
+	// FIXME: make sure this matches exactly the pixel
+	char buf[100];
+	snprintf(buf, 100, "Pos: %03d %03d Magn: %.3e Val: %+.3e%+.3ei Arg: %+.2f", x2, y2,
+			cabsf(val), crealf(val), cimagf(val), cargf(val));
+
+	gtk_entry_set_text(v->gtk_entry, buf);
+
+	return FALSE;
+}
+
+
 extern gboolean button_press_event(GtkWidget *widget, GdkEventButton *event, gpointer data)
 {
 	struct view_s* v = data;
@@ -419,35 +442,18 @@ extern gboolean button_press_event(GtkWidget *widget, GdkEventButton *event, gpo
 		gtk_adjustment_set_value(v->gtk_posall[v->xdim], x2);
 		gtk_adjustment_set_value(v->gtk_posall[v->ydim], y2);
 
+		update_status_bar(v, x2, y2);
+
 		for (struct view_s* v2 = v->next; v2 != v; v2 = v2->next) {
 
 			if (v->sync && v2->sync) {
 
 				gtk_adjustment_set_value(v2->gtk_posall[v->xdim], x2);
 				gtk_adjustment_set_value(v2->gtk_posall[v->ydim], y2);
+				update_status_bar(v2, x2, y2);
 			}
 		}
 	}
-
-	if (event->button == GDK_BUTTON_SECONDARY) {
-
-		float pos[DIMS];
-		
-		for (int i = 0; i < DIMS; i++)
-			pos[i] = v->pos[i];
-
-		pos[v->xdim] = x2;
-		pos[v->ydim] = y2;
-
-		complex float val = sample(DIMS, pos, v->dims, v->strs, v->data);
-		// FIXME: make sure this matches exactly the pixel
-		char buf[100];
-		snprintf(buf, 100, "Pos: %03d %03d Magn: %.3e Val: %+.3e%+.3ei Arg: %+.2f", x2, y2, 
-				cabsf(val), crealf(val), cimagf(val), cargf(val));
-		
-		gtk_entry_set_text(v->gtk_entry, buf);
-	}
-
 	return FALSE;
 }
 

--- a/src/view.c
+++ b/src/view.c
@@ -38,67 +38,6 @@ const char* viewer_gui =
 #include "viewer.inc"
 ;
 
-struct view_s {
-
-	struct view_s* next;
-	struct view_s* prev;
-	bool sync;
-
-	const char* name;
-
-	// geometry
-	long* pos; //[DIMS];
-	int xdim;
-	int ydim;
-	double xzoom;
-	double yzoom;
-	enum flip_t { OO, XO, OY, XY } flip;
-	bool transpose;
-
-	// representation
-	enum mode_t mode;
-	double winhigh;
-	double winlow;
-	double phrot;
-	double max;
-
-	complex float* buf;
-
-	cairo_surface_t* source;
-
-	// rgb buffer
-	int rgbh;
-	int rgbw;
-	int rgbstr;
-	unsigned char* rgb;
-	bool invalid;
-	bool rgb_invalid;
-
-	// data	
-	long dims[DIMS];
-	long strs[DIMS];
-	const complex float* data;
-
-	// widgets
-	GtkComboBox* gtk_mode;
-	GtkComboBox* gtk_flip;
-	GtkWidget* gtk_drawingarea;
-	GtkWidget* gtk_viewport;
-	GtkAdjustment* gtk_winlow;
-	GtkAdjustment* gtk_winhigh;
-	GtkAdjustment* gtk_zoom;
-	GtkAdjustment* gtk_aniso;
-	GtkEntry* gtk_entry;
-	GtkToggleToolButton* gtk_transpose;
-
-	GtkAdjustment* gtk_posall[DIMS];
-	GtkCheckButton* gtk_checkall[DIMS];
-
-	// windowing
-	int lastx;
-	int lasty;
-};
-
 
 
 static void add_text(cairo_surface_t* surface, int x, int y, int size, const char* text)
@@ -108,11 +47,11 @@ static void add_text(cairo_surface_t* surface, int x, int y, int size, const cha
 
 	PangoLayout* layout = pango_cairo_create_layout(cr);
 	pango_layout_set_text(layout, text, -1);
- 	PangoFontDescription* desc = pango_font_description_new();
+	PangoFontDescription* desc = pango_font_description_new();
 	pango_font_description_set_family(desc, "sans");
 	pango_font_description_set_weight(desc, PANGO_WEIGHT_BOLD);
 	pango_font_description_set_absolute_size(desc, size * PANGO_SCALE);
- 	pango_layout_set_font_description(layout, desc);
+	pango_layout_set_font_description(layout, desc);
 	pango_font_description_free(desc);
 
 	int w = 0;

--- a/src/view.h
+++ b/src/view.h
@@ -3,68 +3,7 @@
 #define DIMS 16
 #endif
 
-#include "draw.h"
-struct view_s {
-
-	struct view_s* next;
-	struct view_s* prev;
-	bool sync;
-
-	const char* name;
-
-	// geometry
-	long* pos; //[DIMS];
-	int xdim;
-	int ydim;
-	double xzoom;
-	double yzoom;
-	enum flip_t { OO, XO, OY, XY } flip;
-	bool transpose;
-
-	// representation
-	enum mode_t mode;
-	double winhigh;
-	double winlow;
-	double phrot;
-	double max;
-
-	complex float* buf;
-
-	cairo_surface_t* source;
-
-	// rgb buffer
-	int rgbh;
-	int rgbw;
-	int rgbstr;
-	unsigned char* rgb;
-	bool invalid;
-	bool rgb_invalid;
-
-	// data
-	long dims[DIMS];
-	long strs[DIMS];
-	const complex float* data;
-
-	// widgets
-	GtkComboBox* gtk_mode;
-	GtkComboBox* gtk_flip;
-	GtkWidget* gtk_drawingarea;
-	GtkWidget* gtk_viewport;
-	GtkAdjustment* gtk_winlow;
-	GtkAdjustment* gtk_winhigh;
-	GtkAdjustment* gtk_zoom;
-	GtkAdjustment* gtk_aniso;
-	GtkEntry* gtk_entry;
-	GtkToggleToolButton* gtk_transpose;
-
-	GtkAdjustment* gtk_posall[DIMS];
-	GtkCheckButton* gtk_checkall[DIMS];
-
-	// windowing
-	int lastx;
-	int lasty;
-};
-
+struct view_s;
 
 extern struct view_s* window_new(const char* name, long* pos, const long dims[DIMS], const complex float* x);
 

--- a/src/view.h
+++ b/src/view.h
@@ -3,7 +3,68 @@
 #define DIMS 16
 #endif
 
-struct view_s;
+#include "draw.h"
+struct view_s {
+
+	struct view_s* next;
+	struct view_s* prev;
+	bool sync;
+
+	const char* name;
+
+	// geometry
+	long* pos; //[DIMS];
+	int xdim;
+	int ydim;
+	double xzoom;
+	double yzoom;
+	enum flip_t { OO, XO, OY, XY } flip;
+	bool transpose;
+
+	// representation
+	enum mode_t mode;
+	double winhigh;
+	double winlow;
+	double phrot;
+	double max;
+
+	complex float* buf;
+
+	cairo_surface_t* source;
+
+	// rgb buffer
+	int rgbh;
+	int rgbw;
+	int rgbstr;
+	unsigned char* rgb;
+	bool invalid;
+	bool rgb_invalid;
+
+	// data
+	long dims[DIMS];
+	long strs[DIMS];
+	const complex float* data;
+
+	// widgets
+	GtkComboBox* gtk_mode;
+	GtkComboBox* gtk_flip;
+	GtkWidget* gtk_drawingarea;
+	GtkWidget* gtk_viewport;
+	GtkAdjustment* gtk_winlow;
+	GtkAdjustment* gtk_winhigh;
+	GtkAdjustment* gtk_zoom;
+	GtkAdjustment* gtk_aniso;
+	GtkEntry* gtk_entry;
+	GtkToggleToolButton* gtk_transpose;
+
+	GtkAdjustment* gtk_posall[DIMS];
+	GtkCheckButton* gtk_checkall[DIMS];
+
+	// windowing
+	int lastx;
+	int lasty;
+};
+
 
 extern struct view_s* window_new(const char* name, long* pos, const long dims[DIMS], const complex float* x);
 


### PR DESCRIPTION
Hi,

here are some of the changes to view that I find useful.

The first commit changes the behavior when multiple file names are specified on the command line. They are now added to the window list in the same way they are when windows are cloned (in fact, I copied the code from there). To make this work, I had to add an include guard to draw.h and I moved to the definition of struct view_s from the source file to the header.

The second commit adds synced updating of the status bar. I added this to make comparison of similar images easier: Now, when rightclicking on a pixel, the value at that pixel is shown in the status bar of all synced windows.

And finally the last commit: This is just convenience for file managers and tab completion. I am unsure if view is actually the right place for it or if I should simply write a small wrapper script. With this commit, view now ignores final '.', '.hdr', and '.cfl' from all file names on the command line.
'.' is for tab completion, which for me always completes to the filename with a final dot.
'.cfl' and '.hdr' are for file managers, where view can now be set as the default program to handle these files.
