### PR TITLE
fix segfault on toggle_sync in newer GTK

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -561,9 +561,8 @@ static void delete_view(struct view_s* v)
 }
 
 
-extern gboolean toggle_sync(GtkWidget *widget, GtkToggleButton* button, gpointer data)
+extern gboolean toggle_sync(GtkToggleButton* button, gpointer data)
 {
-	UNUSED(widget);
 	UNUSED(button);
 	struct view_s* v = data;
 	v->sync = !v->sync;


### PR DESCRIPTION
Hi Martin,

could you check if the current master of view segfaults with GTK+3 v3.22 when toggling sync using the button? For me, it didn't on jessie (v3.14) but started doing so on stretch (v3.22). This commit should fix that issue.

At first I thought that was a bug introduced in the last pull request, but even resetting view to where `toggle_sync()` was added (a5fbdacb979ed539f692d7b1e7505bb061766ab5) produced the same segfault for me.

With newer versions of GTK+ (at least with 3.22), a segfault is
triggered on changing sync state. The reason for that is that the signal
is called with 2 arguments, but the third argument is used as
struct view_s. According to
	 https://developer.gnome.org/gtk3/stable/GtkToggleButton.html#GtkToggleButton-toggled
the handler is called as
void
user_function (GtkToggleButton *togglebutton,
               gpointer         user_data)
so the first arguemnt is the button (which is unused in view) and the
second is the data we want.

This works on GTK+3 v3.22 and v3.14 at least. I do not know why it
worked before v3.22.