### PR TITLE
Interpolation

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -115,7 +115,7 @@ static void trans_flow(double rgb[3], double a, double b, complex double value)
 // as an extra argument which could save time
 static complex float int_nlinear(int N, const float x[N], const long strs[N], const complex float* in)
 {
- 	return (0 == N) ? in[0]
+	return (0 == N) ? in[0]
 			: (  (1. - x[N - 1]) * int_nlinear(N - 1, x, strs, in + 0)
 		           +       x[N - 1]  * int_nlinear(N - 1, x, strs, in + strs[N - 1]));
 }

--- a/src/draw.h
+++ b/src/draw.h
@@ -4,18 +4,19 @@
 
 enum mode_t { MAGN, MAGN_VIRIDS, CMPL, CMPL_MYGBM, PHSE, PHSE_MYGBM, REAL, FLOW };
 enum flip_t { OO, XO, OY, XY };
+enum interp_t { NLINEAR, NEAREST };
 
-extern complex float sample(int N, const float pos[N], const long dims[N], const long strs[N], const complex float* in);
+extern complex float sample(int N, const float pos[N], const long dims[N], const long strs[N], enum interp_t interpolation, const complex float* in);
 
 extern void resample(int X, int Y, long str, complex float* buf,
 	int N, const double pos[N], const double dx[N], const double dy[N], 
-	const long dims[N], const long strs[N], const complex float* in);
+	const long dims[N], const long strs[N], enum interp_t interpolation, const complex float* in);
 
 extern void draw(int X, int Y, int rgbstr, unsigned char* rgbbuf,
 	enum mode_t mode, float scale, float winlow, float winhigh, float phrot,
 	long str, const complex float* buf);
 
-extern void update_buf(long xdim, long ydim, int N, const long dims[N],  const long strs[N], const long pos[N], enum flip_t flip, double xzoom, double yzoom,
+extern void update_buf(long xdim, long ydim, int N, const long dims[N],  const long strs[N], const long pos[N], enum flip_t flip, enum interp_t interpolation, double xzoom, double yzoom,
 		long rgbw, long rgbh, const complex float* data, complex float* buf);
 
 extern char* get_spec(int i);

--- a/src/view.c
+++ b/src/view.c
@@ -63,6 +63,7 @@ struct view_s {
 	double winlow;
 	double phrot;
 	double max;
+	enum interp_t interpolation;
 
 	complex float* buf;
 
@@ -84,6 +85,7 @@ struct view_s {
 	// widgets
 	GtkComboBox* gtk_mode;
 	GtkComboBox* gtk_flip;
+	GtkComboBox* gtk_interp;
 	GtkWidget* gtk_drawingarea;
 	GtkWidget* gtk_viewport;
 	GtkAdjustment* gtk_winlow;
@@ -285,6 +287,7 @@ extern gboolean geom_callback(GtkWidget *widget, gpointer data)
 	v->yzoom = zoom;
 
 	v->flip = gtk_combo_box_get_active(v->gtk_flip);
+	v->interpolation = gtk_combo_box_get_active(v->gtk_interp);
 	v->transpose = gtk_toggle_tool_button_get_active(v->gtk_transpose);
 
 	if (v->transpose) {
@@ -344,7 +347,7 @@ extern gboolean window_callback(GtkWidget *widget, gpointer data)
 
 static void update_buf_view(struct view_s* v)
 {
-	update_buf(v->xdim, v->ydim, DIMS, v->dims, v->strs, v->pos, v->flip, v->xzoom, v->yzoom,
+	update_buf(v->xdim, v->ydim, DIMS, v->dims, v->strs, v->pos, v->flip, v->interpolation, v->xzoom, v->yzoom,
 		   v->rgbw, v->rgbh, v->data, v->buf);
 }
 
@@ -581,7 +584,7 @@ static void update_status_bar(struct view_s* v, int x2, int y2)
 	pos[v->xdim] = x2;
 	pos[v->ydim] = y2;
 
-	complex float val = sample(DIMS, pos, v->dims, v->strs, v->data);
+	complex float val = sample(DIMS, pos, v->dims, v->strs, v->interpolation, v->data);
 
 	// FIXME: make sure this matches exactly the pixel
 	char buf[100];
@@ -737,6 +740,9 @@ extern struct view_s* window_new(const char* name, const long pos[DIMS], const l
 
 	v->gtk_flip = GTK_COMBO_BOX(gtk_builder_get_object(builder, "flip"));
 	gtk_combo_box_set_active(v->gtk_flip, 0);
+
+	v->gtk_interp = GTK_COMBO_BOX(gtk_builder_get_object(builder, "interp"));
+	gtk_combo_box_set_active(v->gtk_interp, 0);
     
 	v->gtk_transpose = GTK_TOGGLE_TOOL_BUTTON(gtk_builder_get_object(builder, "transpose"));
 	v->gtk_fit = GTK_TOGGLE_TOOL_BUTTON(gtk_builder_get_object(builder, "fit"));

--- a/src/viewer.ui
+++ b/src/viewer.ui
@@ -60,6 +60,20 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="liststore3">
+    <columns>
+      <!-- column-name text -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">NLIN</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">NEAREST</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkAdjustment" id="pos00">
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
@@ -234,6 +248,32 @@
                     <signal name="changed" handler="geom_callback" swapped="no"/>
                     <child>
                       <object class="GtkCellRendererText" id="cellrenderertext2"/>
+                      <attributes>
+                        <attribute name="text">0</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="homogeneous">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkToolItem" id="toolbutton15">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkComboBox" id="interp">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="model">liststore3</property>
+                    <property name="active">0</property>
+                    <signal name="changed" handler="geom_callback" swapped="no"/>
+                    <child>
+                      <object class="GtkCellRendererText" id="cellrenderertext3"/>
                       <attributes>
                         <attribute name="text">0</attribute>
                       </attributes>


### PR DESCRIPTION
This pull request does two things:

1) It corrects the interpolation used in view. Previously, we had an ugly black border since the step size was correct, but the start was not: We actually need to start at negative positions and set pixels outside of the valid range to their nearest neighbor.

2) It adds support for nearest neighbor interpolation, which can be chosen from the GUI and as a command-line option in`cfl2png`.


Here are two small test datasets (2x2 and 3x3) which can be used to verify the interpolation:
https://gist.github.com/hcmh/c9dde7d52bb322187bfc9c9d15bc89e8