### PR TITLE
Cosmetic changes

### DIFF
--- a/src/view.c
+++ b/src/view.c
@@ -481,6 +481,10 @@ static struct xy_s pos2screen(const struct view_s* v, /*const+*/float (*pos)[DIM
 	if ((XY == v->flip) || (OY == v->flip))
 		y = v->dims[v->ydim] - 1 - y;
 
+	// shift to the center of pixels
+	x += 0.5;
+	y += 0.5;
+
 	x *= v->xzoom;
 	y *= v->yzoom;
 

--- a/src/view.c
+++ b/src/view.c
@@ -47,6 +47,7 @@ struct view_s {
 	bool sync;
 
 	bool cross_hair;
+	bool status_bar;
 
 	const char* name;
 
@@ -509,6 +510,8 @@ static void screen2pos(const struct view_s* v, float (*pos)[DIMS], struct xy_s x
 	(*pos)[v->ydim] = y;
 }
 
+
+
 extern gboolean draw_callback(GtkWidget *widget, cairo_t *cr, gpointer data)
 {
 	UNUSED(widget);
@@ -579,6 +582,7 @@ struct view_s* create_view(const char* name, const long pos[DIMS], const long di
 	v->sync = true;
 
 	v->cross_hair = false;
+	v->status_bar = false;
 
 	v->name = name;
 	v->max = 1.;
@@ -640,6 +644,12 @@ extern gboolean toggle_sync(GtkToggleButton* button, gpointer data)
 	return FALSE;
 }
 
+static void clear_status_bar(struct view_s* v)
+{
+	char buf = '\0';
+	gtk_entry_set_text(v->gtk_entry, &buf);
+}
+
 
 static void update_status_bar(struct view_s* v, /*const*/ float (*pos)[DIMS])
 {
@@ -685,6 +695,8 @@ extern gboolean button_press_event(GtkWidget *widget, GdkEventButton *event, gpo
 	if (event->button == GDK_BUTTON_PRIMARY) {
 
 		v->cross_hair = false;
+		v->status_bar = false;
+		clear_status_bar(v);
 
 		v->rgb_invalid = true;
 		update_view(v);
@@ -693,6 +705,7 @@ extern gboolean button_press_event(GtkWidget *widget, GdkEventButton *event, gpo
 	if (event->button == GDK_BUTTON_SECONDARY) {
 
 		v->cross_hair = true;
+		v->status_bar = true;
 
 		set_position(v, v->xdim, pos[v->xdim]);
 		set_position(v, v->ydim, pos[v->ydim]);

--- a/src/view.c
+++ b/src/view.c
@@ -512,6 +512,32 @@ static void screen2pos(const struct view_s* v, float (*pos)[DIMS], struct xy_s x
 
 
 
+static void clear_status_bar(struct view_s* v)
+{
+	char buf = '\0';
+	gtk_entry_set_text(v->gtk_entry, &buf);
+}
+
+
+static void update_status_bar(struct view_s* v, /*const*/ float (*pos)[DIMS])
+{
+	int x2 = (*pos)[v->xdim];
+	int y2 = (*pos)[v->ydim];
+
+	(*pos)[v->xdim] = x2;
+	(*pos)[v->ydim] = y2;
+
+	complex float val = sample(DIMS, *pos, v->dims, v->strs, v->interpolation, v->data);
+
+	// FIXME: make sure this matches exactly the pixel
+	char buf[100];
+	snprintf(buf, 100, "Pos: %03d %03d Magn: %.3e Val: %+.3e%+.3ei Arg: %+.2f", x2, y2,
+		 cabsf(val), crealf(val), cimagf(val), cargf(val));
+
+	gtk_entry_set_text(v->gtk_entry, buf);
+}
+
+
 extern gboolean draw_callback(GtkWidget *widget, cairo_t *cr, gpointer data)
 {
 	UNUSED(widget);
@@ -554,6 +580,19 @@ extern gboolean draw_callback(GtkWidget *widget, cairo_t *cr, gpointer data)
 
 //		float coords[4][2] = { { 0, 0 }, { 100, 0 }, { 0, 100 }, { 100, 100 } };
 //		draw_grid(v->rgbw, v->rgbh, v->rgbstr, (unsigned char (*)[v->rgbw][v->rgbstr / 4][4])v->rgb, &coords, 4, &color_white);
+	}
+
+	if (v->status_bar) {
+
+		float posi[DIMS];
+		for (unsigned int i = 0; i < DIMS; i++)
+			posi[i] = v->pos[i];
+
+		update_status_bar(v, &posi);
+
+		for (struct view_s* v2 = v->next; v2 != v; v2 = v2->next)
+			if (v->sync && v2->sync)
+				update_status_bar(v2, &posi);
 	}
 
 	cairo_set_source_surface(cr, v->source, 0, 0);
@@ -644,31 +683,6 @@ extern gboolean toggle_sync(GtkToggleButton* button, gpointer data)
 	return FALSE;
 }
 
-static void clear_status_bar(struct view_s* v)
-{
-	char buf = '\0';
-	gtk_entry_set_text(v->gtk_entry, &buf);
-}
-
-
-static void update_status_bar(struct view_s* v, /*const*/ float (*pos)[DIMS])
-{
-	int x2 = (*pos)[v->xdim];
-	int y2 = (*pos)[v->ydim];
-
-	(*pos)[v->xdim] = x2;
-	(*pos)[v->ydim] = y2;
-
-	complex float val = sample(DIMS, *pos, v->dims, v->strs, v->interpolation, v->data);
-
-	// FIXME: make sure this matches exactly the pixel
-	char buf[100];
-	snprintf(buf, 100, "Pos: %03d %03d Magn: %.3e Val: %+.3e%+.3ei Arg: %+.2f", x2, y2,
-			cabsf(val), crealf(val), cimagf(val), cargf(val));
-
-	gtk_entry_set_text(v->gtk_entry, buf);
-}
-
 
 extern void set_position(struct view_s* v, unsigned int dim, unsigned int p)
 {
@@ -710,11 +724,6 @@ extern gboolean button_press_event(GtkWidget *widget, GdkEventButton *event, gpo
 		set_position(v, v->xdim, pos[v->xdim]);
 		set_position(v, v->ydim, pos[v->ydim]);
 
-		update_status_bar(v, &pos);
-
-		for (struct view_s* v2 = v->next; v2 != v; v2 = v2->next)
-			if (v->sync && v2->sync)
-				update_status_bar(v2, &pos);
 	}
 
 	return FALSE;


### PR DESCRIPTION
This patch series contains 3 cosmetic changes:

1): `view.c: shift crosshair lines to pixel center`
This simply shifts the crosshairs to the center of the corresponding pixels

2) `make status bar dismissible `
The status bar now behaves just like the crosshairs: It is dismissed (cleared) when the primary mouse button is pressen

3) `change status bar when changing pos`
Now, when changing the position by changing a spin button also updates the status bar. Previously, this only moved the crosshairs. 
Only caveat: it works perfectly only when using the scroll wheel. When we type a new value, we somehow need to trigger a redraw for this to work.