### PR TITLE
Makefile and README modifications for recent versions of OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,12 @@ endif
 
 CC ?= gcc
 CFLAGS ?= -Wall -O2
-CFLAGS += -std=c11 -fopenmp
+
+ifeq ($(BUILDTYPE), MacOSX)
+	CFLAGS += -std=c11 -Xpreprocessor -fopenmp
+else
+	CFLAGS += -std=c11 -fopenmp
+endif
 
 
 ifeq ($(CUDA),1)
@@ -38,6 +43,12 @@ else
     EXPDYN = -export-dynamic
 endif
 
+ifeq ($(BUILDTYPE), MacOSX)
+	LIBFLAGS = -L/opt/local/lib -lm -lpng -lomp
+else
+	LIBFLAGS = -lm -lpng
+endif
+
 -include Makefile.local
 
 
@@ -47,10 +58,10 @@ src/viewer.inc: src/viewer.ui
 	@echo "STRINGIFY(`cat src/viewer.ui`)" > src/viewer.inc
 
 view:	src/main.c src/view.[ch] src/draw.[ch] src/viewer.inc
-	$(CC) $(CFLAGS) $(EXPDYN) -o view -I$(TOOLBOX_INC) `pkg-config --cflags gtk+-3.0` src/main.c src/view.c src/draw.c `pkg-config --libs gtk+-3.0` $(TOOLBOX_LIB)/libmisc.a $(TOOLBOX_LIB)/libnum.a -lm -lpng
+	$(CC) $(CFLAGS) $(EXPDYN) -o view -I$(TOOLBOX_INC) `pkg-config --cflags gtk+-3.0` src/main.c src/view.c src/draw.c `pkg-config --libs gtk+-3.0` $(TOOLBOX_LIB)/libmisc.a $(TOOLBOX_LIB)/libnum.a $(LIBFLAGS)
 
 cfl2png:	src/cfl2png.c src/view.[ch] src/draw.[ch] src/viewer.inc
-	$(CC) $(CFLAGS) $(EXPDYN) -o cfl2png -I$(TOOLBOX_INC) src/cfl2png.c src/draw.c $(TOOLBOX_LIB)/libmisc.a $(TOOLBOX_LIB)/libnum.a -lm -lpng
+	$(CC) $(CFLAGS) $(EXPDYN) -o cfl2png -I$(TOOLBOX_INC) src/cfl2png.c src/draw.c $(TOOLBOX_LIB)/libmisc.a $(TOOLBOX_LIB)/libnum.a $(LIBFLAGS)
 
 install:
 	install view $(DESTDIR)/usr/lib/bart/commands/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Mac OS X:
 sudo port install pkgconfig
 sudo port install gtk3
 sudo port install adwaita-icon-theme
+sudo port install libomp
 
 Linux:
 sudo apt-get install libgtk-3-dev
@@ -25,6 +26,15 @@ sudo apt-get install libgtk-3-dev
 
 
 Compile with make after setting the TOOLBOX_PATH
-environment variable.
+environment variable to the directory where BART
+is installed.
 
+### Usage
 
+`view <images>...`
+
+### Troubleshooting
+
+If an error is raised along the lines of `Gtk-WARNING **: cannot open display`, ensure X11 is installed and running. On later versions of OS X, you may need ![XQuartz](https://www.xquartz.org/) for View to run.
+
+Set the environment variable `DISPLAY=":0"`, run XQuartz, and then retry `view`.


### PR DESCRIPTION
On recent versions of OS X, `X11.app` no longer seems to be included by default. Additionally, recent versions of XCode and corresponding versions of clang don't play nice with OMP by default. This PR adds new compiler flags for OS X/clang to account for these issues and includes some troubleshooting information in the `readme` to help other users get around these issues. 